### PR TITLE
source mapping, imports, pudding support/raw js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,73 @@
-var solc = require('solc');
+var sol = require("solc"),
+    path = require('path'),
+    fs   = require('fs');
+
+function findFilesInDir(startPath,filter){
+    var results = [];
+
+    if (!fs.existsSync(startPath)){
+        console.log("no dir ",startPath);
+        return;
+    }
+
+    var files=fs.readdirSync(startPath);
+    for(var i=0;i<files.length;i++){
+        var filename=path.join(startPath,files[i]);
+        var stat = fs.lstatSync(filename);
+        if (stat.isDirectory()){
+            results = results.concat(findFilesInDir(filename,filter)); //recurse
+        }
+        else if (filename.indexOf(filter)>=0) {
+            console.log('-- found: ',filename);
+            results.push(filename);
+        }
+    }
+    return results;
+}
 
 module.exports = function(source) {
+  var files = findFilesInDir(this.context, '.sol'),
+      sourceMap = {},
+      self = this,
+      exportJS = false;
 
-	// console.log(source);
+  this.cacheable();
 
-	this.cacheable();
+  if(typeof this.query !== 'undefined') {
+    var queryString = {};
+    this.query.replace(
+        new RegExp("([^?=&]+)(=([^&]*))?", "g"),
+        function($0, $1, $2, $3) { queryString[$1] = $3; }
+    );
 
-	var compiledSOLfile = solc.compile(source, 1);
+    if(queryString.export && queryString.export === 'false')
+      exportJS = false;
 
-	// console.log(compiledSOLfile);
+    if(queryString.export && queryString.export === 'true')
+      exportJS = true;
+  }
 
-	return compiledSOLfile;
+  files.forEach(function(filePath, index){
+    var fileName = filePath.split("/").pop();
+
+    sourceMap[fileName] = fs.readFileSync(filePath, 'utf8');
+    self.addDependency(filePath);
+  });
+
+  var compiled = sol.compile({sources: sourceMap}, 1);
+
+  if(exportJS) {
+    var fileString = "module.exports = {'contracts': " + JSON.stringify(compiled.contracts) + ", ";
+    fileString += "'sources': " + JSON.stringify(compiled.sources) + ", ";
+
+    Object.keys(compiled.contracts).forEach(function(contractName){
+      fileString += "'" + contractName + "': (typeof web3 !== 'undefined' ? web3.eth.contract(" + compiled.contracts[contractName].interface + ") : {}),";
+    });
+
+    fileString = fileString.replace(/,\s*$/, "") + "}; ";
+
+    return fileString;
+  }else{
+    return compiled;
+  }
 }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function(source) {
 
   this.cacheable();
 
-  if(typeof this.query !== 'undefined') {
+  if(typeof this.query !== "undefined") {
     var queryString = {};
     this.query.replace(
         new RegExp("([^?=&]+)(=([^&]*))?", "g"),
@@ -61,7 +61,7 @@ module.exports = function(source) {
     fileString += "'sources': " + JSON.stringify(compiled.sources) + ", ";
 
     Object.keys(compiled.contracts).forEach(function(contractName){
-      fileString += "'" + contractName + "': (typeof web3 !== 'undefined' ? web3.eth.contract(" + compiled.contracts[contractName].interface + ") : {}),";
+      fileString += "'" + contractName + "': " + '(typeof web3 !== "undefined" ? web3.eth.contract(' + compiled.contracts[contractName].interface + ") : {}),";
     });
 
     fileString = fileString.replace(/,\s*$/, "") + "}; ";


### PR DESCRIPTION
Export JS/Modules/Contract Factories

```
{
     test: /\.sol$/,
     exclude: /node_modules/,
     loader: "soldity-loader?export=true",
     include: path.join(__dirname, 'src/contracts/')
}
```

```
var SimpleStore = require("SimpleStore.sol").SimpleStore;
var SimpleStoreContracts = require("SimpleStore.sol").contracts;
var SimpleStoreSources = require("SimpleStore.sol").sources;
```

or for pudding support (the default):

```
 {
     test: /\.sol$/,
     exclude: /node_modules/,
     loader: "soldity-loader?export=false",
     include: path.join(__dirname, 'src/contracts/')
 }
```

or

```
 {
     test: /\.sol$/,
     exclude: /node_modules/,
     loader: "soldity-loader",
     include: path.join(__dirname, 'src/contracts/')
 }
```
