### PR TITLE
contract creation constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,8 +103,8 @@ module.exports = function(source) {
           .forEach(function(contractName){
             fileString += "'" +
             contractName + "': " +
-            '(typeof web3 !== "undefined" ? web3.eth.contract(' +
-            compiled.contracts[contractName].interface +") : {}),";
+            'function (web3) { var contract = web3.eth.contract(' +
+            compiled.contracts[contractName].interface +"); contract.bytecode = '" + compiled.contracts[contractName].bytecode + "'; return contract; },";
           });
 
     // Cleans up spaces for conciseness


### PR DESCRIPTION
Instead of checking if the web3 object exists, enable ability to pass in the web3 object.

```
// ./contracts/SimpleStore.sol:
contract SimpleStore {
  uint public store;

  function set(uint _value) {
    store = _value;
  }

  function get() returns (uint _value) {
    return store;
  }
}
```

```
// ./index.js:
const web3 = new (require('web3'))()
const AllContracts = require('./contracts/SimpleStore.sol').contracts
const AllSources = require('./contracts/SimpleStore.sol').sources
const SimpleStore = require('./contracts/SimpleStore.sol').SimpleStore(web3)

const simpleStoreInstance = SimpleStore.at('0x000...');
simpleStoreInstance.set(...)
simpleStoreInstance.get()

// or
const SimpleStore2 = require('./contracts/SimpleStore.sol').SimpleStore
const simpleStore2Instance = SimpleStore2(web3).at('0x000...');
```

Passing in the web3 is a better design pattern than most alternative.
